### PR TITLE
Fix blank gallery after first boot

### DIFF
--- a/services/core/java/com/android/server/pm/DefaultPermissionGrantPolicy.java
+++ b/services/core/java/com/android/server/pm/DefaultPermissionGrantPolicy.java
@@ -608,6 +608,17 @@ final class DefaultPermissionGrantPolicy {
             }
             mService.mSettings.onDefaultRuntimePermissionsGrantedLPr(userId);
 
+            // Gallery
+            PackageParser.Package gallerypackage = getSystemPackageLPr(
+                    "com.android.gallery3d");
+            if (gallerypackage != null && doesPackageSupportRuntimePermissions(gallerypackage)) {
+                grantRuntimePermissionsLPw(gallerypackage, CAMERA_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gallerypackage, CONTACTS_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gallerypackage, LOCATION_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gallerypackage, MICROPHONE_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gallerypackage, STORAGE_PERMISSIONS, userId);
+            }
+
             // Google Account
             PackageParser.Package googleaccountPackage = getSystemPackageLPr(
                     "com.google.android.gsf.login");


### PR DESCRIPTION
Since gallery doesn't ask permissions itself, user needs to manually give permissions in settings.
Instead provide permissions on parsing.
