### PR TITLE
networkClassToString invalid input

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/CarrierText.java
+++ b/packages/Keyguard/src/com/android/keyguard/CarrierText.java
@@ -429,7 +429,7 @@ public class CarrierText extends TextView {
             com.android.internal.R.string.config_rat_3g,
             com.android.internal.R.string.config_rat_4g };
         String classString = null;
-        if (networkClass < classIds.length) {
+        if (networkClass >= 0 && networkClass < classIds.length) {
             classString = getContext().getResources().getString(classIds[networkClass]);
         }
         return (classString == null) ? "" : classString;


### PR DESCRIPTION
My systemui crashed and the below is the logcat.
-------------------------------------------------------------
FATAL EXCEPTION: main
Process: com.android.systemui, PID: 29537
android.content.res.Resources$NotFoundException: String resource ID #0x0
	at android.content.res.Resources.getText(Resources.java:335)
	at android.content.res.Resources.getString(Resources.java:381)
	at com.android.keyguard.CarrierText.networkClassToString(CarrierText.java:433)
	at com.android.keyguard.CarrierText.updateCarrierText(CarrierText.java:131)
	at com.android.keyguard.CarrierText$1.onRefreshCarrierInfo(CarrierText.java:59)
	at com.android.keyguard.KeyguardUpdateMonitor.sendUpdates(KeyguardUpdateMonitor.java:1549)
	at com.android.keyguard.KeyguardUpdateMonitor.registerCallback(KeyguardUpdateMonitor.java:1540)
	at com.android.keyguard.CarrierText.onAttachedToWindow(CarrierText.java:240)
-------------------------------------------------------------

The proposed PR is to check if networkClass value is within the array.
I'm not a java coder. There might be better code for this but I believe at least this will work.

Please kindly refer to attached image for context.

![2016-11-28-network-1](https://cloud.githubusercontent.com/assets/1405353/20660570/585a9472-b585-11e6-9794-1628f2f13360.PNG)
