### PR TITLE
Update nfc java libraries

### DIFF
--- a/core/java/android/nfc/INfcAdapter.aidl
+++ b/core/java/android/nfc/INfcAdapter.aidl
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +33,7 @@ import android.nfc.INfcFCardEmulation;
 import android.nfc.INfcUnlockHandler;
 import android.nfc.ITagRemovedCallback;
 import android.os.Bundle;
+import android.os.IBinder;
 
 /**
  * @hide
@@ -40,6 +44,7 @@ interface INfcAdapter
     INfcCardEmulation getNfcCardEmulationInterface();
     INfcFCardEmulation getNfcFCardEmulationInterface();
     INfcAdapterExtras getNfcAdapterExtrasInterface(in String pkg);
+    IBinder getNfcAdapterVendorInterface(in String vendor);
 
     int getState();
     boolean disable(boolean saveState);

--- a/core/java/android/nfc/cardemulation/AidGroup.java
+++ b/core/java/android/nfc/cardemulation/AidGroup.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2015 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +40,7 @@ import android.util.Log;
  *
  * @hide
  */
-public final class AidGroup implements Parcelable {
+public class AidGroup implements Parcelable {
     /**
      * The maximum number of AIDs that can be present in any one group.
      */
@@ -45,9 +48,9 @@ public final class AidGroup implements Parcelable {
 
     static final String TAG = "AidGroup";
 
-    final List<String> aids;
-    final String category;
-    final String description;
+    protected List<String> aids;
+    protected String category;
+    protected String description;
 
     /**
      * Creates a new AidGroup object.

--- a/core/java/android/nfc/cardemulation/ApduServiceInfo.java
+++ b/core/java/android/nfc/cardemulation/ApduServiceInfo.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2013 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,53 +51,53 @@ import java.util.Map;
 /**
  * @hide
  */
-public final class ApduServiceInfo implements Parcelable {
+public class ApduServiceInfo implements Parcelable {
     static final String TAG = "ApduServiceInfo";
 
     /**
      * The service that implements this
      */
-    final ResolveInfo mService;
+    protected ResolveInfo mService;
 
     /**
      * Description of the service
      */
-    final String mDescription;
+    protected String mDescription;
 
     /**
      * Whether this service represents AIDs running on the host CPU
      */
-    final boolean mOnHost;
+    protected boolean mOnHost;
 
     /**
      * Mapping from category to static AID group
      */
-    final HashMap<String, AidGroup> mStaticAidGroups;
+    protected HashMap<String, AidGroup> mStaticAidGroups;
 
     /**
      * Mapping from category to dynamic AID group
      */
-    final HashMap<String, AidGroup> mDynamicAidGroups;
+    protected HashMap<String, AidGroup> mDynamicAidGroups;
 
     /**
      * Whether this service should only be started when the device is unlocked.
      */
-    final boolean mRequiresDeviceUnlock;
+    protected boolean mRequiresDeviceUnlock;
 
     /**
      * The id of the service banner specified in XML.
      */
-    final int mBannerResourceId;
+    protected int mBannerResourceId;
 
     /**
      * The uid of the package the service belongs to
      */
-    final int mUid;
+    protected int mUid;
 
     /**
      * Settings Activity for this service
      */
-    final String mSettingsActivityName;
+    protected String mSettingsActivityName;
 
     /**
      * @hide

--- a/core/java/android/nfc/tech/MifareClassic.java
+++ b/core/java/android/nfc/tech/MifareClassic.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright (C) 2015 NXP Semiconductors
+ * The original Work has been changed by NXP Semiconductors.
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,6 +174,10 @@ public final class MifareClassic extends BasicTagTechnology {
         case 0x18:
             mType = TYPE_CLASSIC;
             mSize = SIZE_4K;
+            break;
+        case 0x19:
+            mType = TYPE_CLASSIC;
+            mSize = SIZE_2K;
             break;
         case 0x28:
             mType = TYPE_CLASSIC;

--- a/core/java/android/nfc/tech/NfcA.java
+++ b/core/java/android/nfc/tech/NfcA.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright (C) 2015 NXP Semiconductors
+ * The original Work has been changed by NXP Semiconductors.
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,8 +68,15 @@ public final class NfcA extends BasicTagTechnology {
     /** @hide */
     public NfcA(Tag tag) throws RemoteException {
         super(tag, TagTechnology.NFC_A);
-        Bundle extras = tag.getTechExtras(TagTechnology.NFC_A);
-        mSak = extras.getShort(EXTRA_SAK);
+        Bundle extras;
+        mSak = 0;
+        if(tag.hasTech(TagTechnology.MIFARE_CLASSIC))
+        {
+            extras = tag.getTechExtras(TagTechnology.MIFARE_CLASSIC);
+            mSak = extras.getShort(EXTRA_SAK);
+        }
+        extras = tag.getTechExtras(TagTechnology.NFC_A);
+        mSak |= extras.getShort(EXTRA_SAK);
         mAtqa = extras.getByteArray(EXTRA_ATQA);
     }
 


### PR DESCRIPTION
Update nfc java libraries to fix build on other devices with newer NFC configs. Please check first if it has any sideeffects or problems with Kenzo.

Works fine with NFC App from LAOS and their nxp-nfc repos.

"Stolen" from https://github.com/LineageOS/android_frameworks_base/commit/df660b811e3b469396aa46b79ab1437a112f7f3f and applied it to your frameworks/base