### PR TITLE
Telephony: Conditionally ignore RSSNR signal level

### DIFF
--- a/core/res/res/values/nitrogen_config.xml
+++ b/core/res/res/values/nitrogen_config.xml
@@ -122,4 +122,8 @@
     <!-- Whether device needs to wait for Qualcomm MPCTL service to start
          before setting power profiles on boot. -->
     <bool name="config_waitForMpctlOnBoot">false</bool>
+
+    <!-- Whether device ignores the RSSNR signal implementation -->
+    <bool name="config_ignoreRssnrSignalLevel">false</bool>
+
 </resources>

--- a/core/res/res/values/nitrogen_symbols.xml
+++ b/core/res/res/values/nitrogen_symbols.xml
@@ -127,4 +127,8 @@
   <!-- Whether device needs to wait for Qualcomm MPCTL service to start
        before setting power profiles on boot. -->
   <java-symbol type="bool" name="config_waitForMpctlOnBoot" />
+
+  <!-- Whether device ignores the RSSNR signal implementation -->
+  <java-symbol type="bool" name="config_ignoreRssnrSignalLevel" />
+
 </resources>

--- a/telephony/java/android/telephony/SignalStrength.java
+++ b/telephony/java/android/telephony/SignalStrength.java
@@ -900,7 +900,15 @@ public class SignalStrength implements Parcelable {
                     + rsrpIconLevel + " snrIconLevel:" + snrIconLevel
                     + " lteRsrpBoost:" + mLteRsrpBoost);
 
-            /* Choose a measurement type to use for notification */
+               /* Ignore RSSNR for now, conditionally */
+        boolean rssnrIgnored = Resources.getSystem().getBoolean(
+                com.android.internal.R.bool.config_ignoreRssnrSignalLevel);
+        if (rssnrIgnored) {
+            // Ignore RSSNR
+            if (rsrpIconLevel != -1) return rsrpIconLevel;
+        }
+
+               /* Choose a measurement type to use for notification */
             if (snrIconLevel != -1 && rsrpIconLevel != -1) {
                 /*
                  * The number of bars displayed shall be the smaller of the bars


### PR DESCRIPTION
Doesn't work properly on some devices, so allow those devices to disable this.
Based on the phhusson treble patch.